### PR TITLE
Add fallback for missing plugin README files

### DIFF
--- a/src/pages/plugins/[slug].astro
+++ b/src/pages/plugins/[slug].astro
@@ -4,7 +4,7 @@ import Sidebar from '../../components/Sidebar.astro';
 import Breadcrumbs from '../../components/Breadcrumbs.astro';
 import { getCollection } from 'astro:content';
 import { GITHUB_ORG_URL, DISCORD_URL } from '../../lib/config';
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 
 export async function getStaticPaths() {
   const allItems = await getCollection('plugins');
@@ -18,7 +18,8 @@ export async function getStaticPaths() {
 const { plugin } = Astro.props;
 const { name, description, version, githubUrl, wordpressUrl, stars, forks, openIssues, lastPush, license, language, defaultBranch } = plugin.data;
 
-const safeReadmeHtml = readFileSync(`src/data/readmes/${plugin.id}.html`, 'utf-8');
+const readmePath = `src/data/readmes/${plugin.id}.html`;
+const safeReadmeHtml = existsSync(readmePath) ? readFileSync(readmePath, 'utf-8') : `<p>No README available. Visit the <a href="${githubUrl}">GitHub repository</a> for more information.</p>`;
 const downloadUrl = `${githubUrl}/archive/refs/heads/${defaultBranch}.zip`;
 
 function formatDate(dateStr: string): string {


### PR DESCRIPTION
## Summary
This change adds graceful error handling for plugin pages when README files are missing from the file system. Instead of crashing when a README doesn't exist, the page now displays a helpful fallback message with a link to the GitHub repository.

## Key Changes
- Import `existsSync` from `node:fs` to check file existence before reading
- Extract the README file path to a variable for reusability
- Add conditional logic to check if the README file exists before attempting to read it
- Provide a user-friendly fallback message that directs users to the GitHub repository when no README is available

## Implementation Details
The fallback message is rendered as HTML and includes a direct link to the plugin's GitHub repository, ensuring users can still access documentation even when the cached README file is missing. This improves robustness when dealing with incomplete or outdated file caches.

https://claude.ai/code/session_01NNqemC6vCfiJnq58btitwm