### PR TITLE
Use plugin lastPush date for "Last updated" instead of build date

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,19 @@
 ---
 import { GITHUB_ORG_URL, DISCORD_URL, SPONSOR_URL, CONTACT_EMAIL, TWITTER_URL } from '../lib/config';
+import pluginsData from '../data/plugins.json';
+
 const year = new Date().getFullYear();
-const buildDate = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+// Use the most recent lastPush date from plugins data instead of the build date,
+// so "Last updated" reflects when content actually changed, not when the site was built.
+const lastUpdated = pluginsData
+  .map((p: { lastPush?: string }) => p.lastPush)
+  .filter(Boolean)
+  .sort()
+  .pop();
+const buildDate = lastUpdated
+  ? new Date(lastUpdated).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  : new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 ---
 
 <footer class="bg-gray-900 dark:bg-gray-950 text-white">

--- a/src/pages/humans.txt.ts
+++ b/src/pages/humans.txt.ts
@@ -28,7 +28,13 @@ export const GET: APIRoute = async () => {
 
   lines.push('/* SITE */');
   lines.push('');
-  lines.push('  Last update: ' + new Date().toISOString().split('T')[0]);
+  // Use most recent plugin push date instead of build date
+  const lastPush = plugins
+    .map((p) => p.data.lastPush)
+    .filter(Boolean)
+    .sort()
+    .pop();
+  lines.push('  Last update: ' + (lastPush ? new Date(lastPush).toISOString().split('T')[0] : new Date().toISOString().split('T')[0]));
   lines.push('  Language: English');
   lines.push('  Standards: HTML5, CSS3');
   lines.push('  Framework: Astro');


### PR DESCRIPTION
## Summary
Updated the footer and humans.txt to display the most recent plugin update date instead of the site build date, ensuring the "Last updated" information reflects when content actually changed.

## Key Changes
- **Footer.astro**: Modified to extract the most recent `lastPush` date from the plugins data and use it for the build date display
- **humans.txt.ts**: Updated the site's last update timestamp to use the most recent plugin push date instead of the current build time
- Both changes include fallback logic to use the current date if no plugin push dates are available

## Implementation Details
- The logic sorts all available `lastPush` dates from plugins and selects the most recent one using `.pop()`
- Includes filtering with `Boolean` to exclude undefined/null values
- Maintains backward compatibility with fallback to current date when no plugin data is available
- Consistent implementation pattern applied across both files

https://claude.ai/code/session_01NTroCNvpX5YbMHABWcVnsw